### PR TITLE
Fixed broken link in BrilDB blog post

### DIFF
--- a/content/blog/2019-09-25-brildb.md
+++ b/content/blog/2019-09-25-brildb.md
@@ -235,5 +235,5 @@ program terminated.
 [GDB]: https://www.gnu.org/software/gdb/
 [LLDB]: https://lldb.llvm.org
 [Bril]: https://capra.cs.cornell.edu/bril/
-[BrilDB]: https://github.com/anastos/bril/tree/master/brildb
+[BrilDB]: https://github.com/anastos/bril/tree/brildb/brildb
 [Parsec]: https://hackage.haskell.org/package/parsec


### PR DESCRIPTION
I modified the structure of my Bril fork and broke the link in my blog post. This fixes that.