### PR TITLE
fix task link

### DIFF
--- a/templates/lessons.html
+++ b/templates/lessons.html
@@ -19,7 +19,7 @@
     {% endfor %}
     {% if page.extra.due %}
     <li>
-      <a href="#tasks" class="icon due">tasks</a> due <strong>{{page.extra.due}}</strong>
+      <a href="{{ page.permalink }}/#tasks" class="icon due">tasks</a> due <strong>{{page.extra.due}}</strong>
     </li>
     {% endif %}
   </ul>


### PR DESCRIPTION
This just fixes the task link on the lessons page since it was missing the lesson perma-link.