### PR TITLE
Fix paper link in Lesson 1

### DIFF
--- a/content/lesson/1.md
+++ b/content/lesson/1.md
@@ -7,7 +7,7 @@ index = 1
 id = "0_bug89uok"
 [[extra.readings]]
 name = "On Proebsting’s Law"
-url = "https://pdfs.semanticscholar.org/0a2b/1aa8bb63fb545f7f41233e5d6c0206486ccc.pdf"
+url = "http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.29.434&rep=rep1&type=pdf"
 details = "Kevin Scott"
 +++
 


### PR DESCRIPTION
The semanticscholar page directs to http://www.cs.virginia.edu/~techrep/CS-2001-12.pdf, which is apparently 404 now.