### PR TITLE
Move bril links from master to main

### DIFF
--- a/content/lesson/2.md
+++ b/content/lesson/2.md
@@ -34,11 +34,11 @@ name = "getting started with Bril"
         * The [documentation][bril-docs].
         * The [git repository][bril].
         * Lots of examples in the `tests` and `benchmarks` directories.
-            * An extremely simple example: [`add.json`](https://github.com/sampsyo/bril/blob/master/test/print/add.json) in the canonical representation, or [the equivalent text for your human convenience](https://github.com/sampsyo/bril/blob/master/test/print/add.bril).
+            * An extremely simple example: [`add.json`](https://github.com/sampsyo/bril/blob/main/test/print/add.json) in the canonical representation, or [the equivalent text for your human convenience](https://github.com/sampsyo/bril/blob/main/test/print/add.bril).
         * How to load up and process a Bril program, using Python as an example, but remember that you can use any language you like.
         * Getting started with generating the CFG.
             * Try it yourself!
-            * Afterward, if you're curious, check out a completed implementation (with some added fanciness) in [the examples directory](https://github.com/sampsyo/bril/tree/master/examples) (see `form_blocks.py`, `cfg.py`, and `cfg_dot.py`).
+            * Afterward, if you're curious, check out a completed implementation (with some added fanciness) in [the examples directory](https://github.com/sampsyo/bril/tree/main/examples) (see `form_blocks.py`, `cfg.py`, and `cfg_dot.py`).
 * [Turnt][] is a tool you might like for testing compiler tools.
 
 
@@ -64,11 +64,11 @@ Your goal is to get familiar with [Bril][].
 
 [bril]: https://github.com/sampsyo/bril
 [bril-docs]: https://capra.cs.cornell.edu/bril/
-[add]: https://github.com/sampsyo/bril/blob/master/test/parse/add.json
+[add]: https://github.com/sampsyo/bril/blob/main/test/parse/add.json
 [turnt]: https://github.com/cucapra/turnt
 [ts2bril]: https://capra.cs.cornell.edu/bril/tools/ts2bril.html
 [brili]: https://capra.cs.cornell.edu/bril/tools/brilirs.html
-[benchdir]: https://github.com/sampsyo/bril/tree/master/benchmarks
-[bmdocs]: https://github.com/sampsyo/bril/blob/master/docs/tools/bench.md
+[benchdir]: https://github.com/sampsyo/bril/tree/main/benchmarks
+[bmdocs]: https://github.com/sampsyo/bril/blob/main/docs/tools/bench.md
 [zulip]: https://cs6120.zulipchat.com
 [cms]: https://cmsx.cs.cornell.edu/

--- a/content/lesson/3.md
+++ b/content/lesson/3.md
@@ -33,7 +33,7 @@ Then, our first optimizations!
   * Derive an algorithm for removing them.
   * Then implement that too.
 * Let's try our new optimization pass out on the Bril benchmarks.
-  * When working on your implementations, try them on [`simple.bril`](https://github.com/sampsyo/bril/blob/master/examples/test/tdce/simple.bril), [`reassign.bril`](https://github.com/sampsyo/bril/blob/master/examples/test/tdce/reassign.bril), and other examples in [the DCE test directory](https://github.com/sampsyo/bril/tree/master/examples/test/tdce) to see if they actually work.
+  * When working on your implementations, try them on [`simple.bril`](https://github.com/sampsyo/bril/blob/main/examples/test/tdce/simple.bril), [`reassign.bril`](https://github.com/sampsyo/bril/blob/main/examples/test/tdce/reassign.bril), and other examples in [the DCE test directory](https://github.com/sampsyo/bril/tree/main/examples/test/tdce) to see if they actually work.
   * First, combine all your implementations into one command somehow (including iterating to convergence). Try out your pass—something like this:
 
         $ bril2json < bench.bril | python3 tdce.py | bril2txt
@@ -95,7 +95,7 @@ Here's the pseudocode from the video:
 
 You can see my implementation in `lvn.py` in [the examples directory][ex] in the Bril repository. But seriously, don't be tempted! You want to write your implementation without looking at mine!
 
-[ex]: https://github.com/sampsyo/bril/tree/master/examples
+[ex]: https://github.com/sampsyo/bril/tree/main/examples
 
 
 ## Tasks

--- a/content/lesson/5.md
+++ b/content/lesson/5.md
@@ -84,4 +84,4 @@ The last criterion is somewhat tricky: it ensures that the computation would hav
     * Compute the dominance frontier.
 * TK testing.
 
-[is_ssa]: https://github.com/sampsyo/bril/blob/master/examples/is_ssa.py
+[is_ssa]: https://github.com/sampsyo/bril/blob/main/examples/is_ssa.py

--- a/content/lesson/6.md
+++ b/content/lesson/6.md
@@ -206,4 +206,4 @@ For a more extensive take on how to translate out of SSA efficiently, see [“Re
     * You'll also want to make sure that programs do the same thing when converted to SSA form and back again. Fortunately, [brili][] supports the `phi` instruction, so you can interpret your SSA-form programs if you want to check the midpoint of that round trip.
 * For bonus "points," implement global value numbering for SSA-form Bril code.
 
-[is_ssa]: https://github.com/sampsyo/bril/blob/master/examples/is_ssa.py
+[is_ssa]: https://github.com/sampsyo/bril/blob/main/examples/is_ssa.py


### PR DESCRIPTION
Prevents the github popup saying bril's default branch moved from master to main.