### PR TITLE
Update ML Pointers Link in Alias Analysis Lesson

### DIFF
--- a/content/lesson/10.md
+++ b/content/lesson/10.md
@@ -83,6 +83,6 @@ If alias analysis is your bag, you can start with using your data flow implement
 
 [mem]: https://capra.cs.cornell.edu/bril/lang/memory.html
 [patut]: https://yanniss.github.io/points-to-tutorial15.pdf
-[ocamlptr]: https://ocaml.org/learn/tutorials/pointers.html
+[ocamlptr]: https://ocaml.org/docs/memory-representation#ocaml-blocks-and-values
 [javaprim]: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html
 [l8]: @/lesson/8.md


### PR DESCRIPTION
Current ML pointers link leads to a 404 error page. I couldn't find the exact same content on the OCaml site. 
Some other possible replacements:
https://web.archive.org/web/20210426110256/https://ocaml.org/learn/tutorials/pointers.html
https://caml.inria.fr/resources/doc/guides/pointers.en.html