### PR TITLE
Add Jiale and Ning to lead paper "SSA Construction"

### DIFF
--- a/data/content.toml
+++ b/data/content.toml
@@ -42,7 +42,7 @@ lesson = 6
 
 [[classes]]
 title = "SSA"
-leader = "Nate Young"
+leader = "Nate Young, Jiale Lao, Ning Wang"
 readings = ["ssa-construct"]
 
 


### PR DESCRIPTION
Jiale and Ning have discussed to lead this paper. Nate Young registered this before, if he is ok with this, we can lead this paper together. Given there are much more students than the number of papers, each paper would have many leaders finally.