### PR TITLE
Add deprecation warning for phi instructions

### DIFF
--- a/content/lesson/6.md
+++ b/content/lesson/6.md
@@ -61,7 +61,7 @@ Of course, things will get a little more complicated when there is control flow.
 And because real machines are not SSA, using separate variables (i.e., memory locations and registers) for everything is bound to be inefficient.
 The idea in SSA is to convert general programs into SSA form, do all our optimization there, and then convert back to a standard mutating form before we generate backend code.
 
-### ϕ-Nodes
+### ϕ-Nodes {###Phi-Nodes}
 
 Just renaming assignments willy-nilly will quickly run into problems.
 Consider this program:
@@ -391,12 +391,15 @@ An optimization that stitches together two blocks, for instance, can leave `get`
 
 ### Bril in SSA
 
+**Warning**: The `phi` instruction described in [ϕ-Nodes](###Phi-Nodes) is [deprecated][bril-ssa1] in the reference interpreter.
+
 Bril has an [SSA extension][bril-ssa2] that follows the "upsilon/phi form" representation.
 It adds support for `set` and `get` instructions, which correspond to Pizlo's upsilon and phi operations.
 Beyond that, SSA form is just a restriction on the normal expressiveness of Bril—if you solemnly promise never to assign statically to the same variable twice, you are writing "SSA Bril."
 
 The [reference interpreter][brili] has built-in support for `set` and `get`, so you can execute your SSA-form Bril programs without fuss.
 
+[bril-ssa1]: https://capra.cs.cornell.edu/bril/lang/ssa.html
 [bril-ssa2]: https://capra.cs.cornell.edu/bril/lang/ssa2.html
 [brili]: https://capra.cs.cornell.edu/bril/tools/interp.html
 

--- a/content/lesson/6.md
+++ b/content/lesson/6.md
@@ -61,7 +61,7 @@ Of course, things will get a little more complicated when there is control flow.
 And because real machines are not SSA, using separate variables (i.e., memory locations and registers) for everything is bound to be inefficient.
 The idea in SSA is to convert general programs into SSA form, do all our optimization there, and then convert back to a standard mutating form before we generate backend code.
 
-### ϕ-Nodes {###Phi-Nodes}
+### ϕ-Nodes {#phi-nodes}
 
 Just renaming assignments willy-nilly will quickly run into problems.
 Consider this program:
@@ -111,6 +111,8 @@ You can write the above program in SSA like this:
     }
 
 It can also be useful to see how ϕ-nodes crop up in loops.
+
+**Warning:** This `phi` instruction in Bril code is for illustration purposes only. Bril previously used `phi` instructions for [an old, now-deprecated version of SSA][bril-ssa1]. See the section below about [SSA in Bril](#bril-ssa) for details about [the current SSA extension][bril-ssa2].
 
 ### The SSA Philosophy
 
@@ -389,9 +391,7 @@ An optimization that stitches together two blocks, for instance, can leave `get`
 
 [pizlo]: https://gist.github.com/pizlonator/79b0aa601912ff1a0eb1cb9253f5e98d
 
-### Bril in SSA
-
-**Warning**: The `phi` instruction described in [ϕ-Nodes](###Phi-Nodes) is [deprecated][bril-ssa1] in the reference interpreter.
+### Bril in SSA {#bril-ssa}
 
 Bril has an [SSA extension][bril-ssa2] that follows the "upsilon/phi form" representation.
 It adds support for `set` and `get` instructions, which correspond to Pizlo's upsilon and phi operations.

--- a/content/lesson/6.md
+++ b/content/lesson/6.md
@@ -112,7 +112,11 @@ You can write the above program in SSA like this:
 
 It can also be useful to see how ϕ-nodes crop up in loops.
 
-**Warning:** This `phi` instruction in Bril code is for illustration purposes only. Bril previously used `phi` instructions for [an old, now-deprecated version of SSA][bril-ssa1]. See the section below about [SSA in Bril](#bril-ssa) for details about [the current SSA extension][bril-ssa2].
+<div class="warning">
+
+This `phi` instruction in Bril code is for illustration purposes only. Bril previously used `phi` instructions for [an old, now-deprecated version of SSA][bril-ssa1]. See the section below about [SSA in Bril](#bril-ssa) for details about [the current SSA extension][bril-ssa2].
+
+</div>
 
 ### The SSA Philosophy
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,6 +1,7 @@
 $main-color: rgb(179, 27, 27);
 $disabled-color: #666;
 $exception-color: #ccc;
+$warning-color: rgb(255, 142, 0);
 $max-width: 40rem;
 $max-width-wide: 60rem;
 
@@ -336,5 +337,26 @@ ul.simple {
     font-size: 0.8em;
     &:before { content: '['; }
     &:after { content: ']'; }
+  }
+}
+
+// Warning blocks. Borrowed from mdBook's stylesheet.
+.warning {
+  margin-left: 20px;
+  padding-left: 20px;
+  border-inline-start: 2px solid $warning-color;
+
+  &:before {
+    position: absolute;
+    width: 20px;
+    height: 28px;
+    margin-inline-start: -32px;
+
+    content: "ⓘ";
+    font-weight: bold;
+    font-size: 1.4rem;
+    text-align: center;
+    color: $warning-color;
+    background: white;
   }
 }


### PR DESCRIPTION
https://github.com/sampsyo/cs6120/discussions/558#discussioncomment-14683676 brought to my attention that phi instructions are deprecated in the current brili interpreter. This PR adds a warning in Lesson 6 to address this.